### PR TITLE
Fix HttpLib test by renaming HttpLib -> Http.

### DIFF
--- a/tests/tst_httplib.qml
+++ b/tests/tst_httplib.qml
@@ -27,7 +27,7 @@ TestCase {
 
         var html = "";
 
-        var promise = HttpLib.get("http://www.google.com")
+        var promise = Http.get("http://www.google.com")
             .then( function(data) {
                 html = data;
         });


### PR DESCRIPTION
In commit 0584797edfb95bd8c319d754a03686b187c6772e HttpLib was renamed to Http but test wasn't updated. This patch fixes that.