### PR TITLE
CircleImage: Property aliases for 'asynchronous' and 'cache'

### DIFF
--- a/modules/Material/Extras/CircleImage.qml
+++ b/modules/Material/Extras/CircleImage.qml
@@ -28,6 +28,8 @@ Item {
     property alias status: image.status
     property alias averageColor: image.averageColor
     property alias sourceSize: image.sourceSize
+    property alias asynchronous: image.asynchronous
+    property alias cache: image.cache
 
     width: image.implicitWidth
     height: image.implicitHeight


### PR DESCRIPTION
In my use case I needed to set the 'asynchronous' flag.
I thought being able to set the 'cache' flag for the image might come in handy, too.