### PR TITLE
Correct the timeout function of XMLHttpRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@ Item {
 
         var promise = new Promises.Promse();
         promise.info.myinfo = "cool info";
-        promise.then = function( data, info ) {
+        promise.then(function( data, info ) {
                 // send data to the next step
                 return info.myinfo + " " + data;
         });
 
-        promise.done = function( data, info ) {
+        promise.done(function( data, info ) {
                 // do something with the data of resolve(...)
         });
 
-        promise.error = function( error, info ) {
+        promise.error(function( error, info ) {
                 // do something with the data of reject(...)
         });
     }

--- a/modules/Material/Extras/js/httplib.js
+++ b/modules/Material/Extras/js/httplib.js
@@ -101,7 +101,7 @@ function request(path, call, args, timeout) {
                 print("Calling back with error...")
                 var error = doc.responseText;
                 if (doc.hasTimeout) {
-                    error = "Conection timeout."
+                    error = "Connection timeout."
                 }
                 promise.reject(error)
             }


### PR DESCRIPTION
The timeout of XMLHttpRequest of QML does not work or is not implemented[1].

Implemented a way to add this support through the QML Timer and the ability for the user optionally specify the desired timeout.

[1] https://www.google.com/search?q=qml+XMLHttpRequest+timeout&ie=utf-8&oe=utf-8